### PR TITLE
Add function that checks for a url or class name in sidebar item

### DIFF
--- a/dist/admin/admin.controller.js
+++ b/dist/admin/admin.controller.js
@@ -298,15 +298,20 @@ var AdminController = function () {
     }
 
     /**
-     * Returns a url for ui-sref fora  sidebar item
-     * @param  {Object} sidebar item (as defined in config)
-     * @return {String} url for class, or current state if not
+     * Goes to the appropriate url after checking if the sidebar item has a URL or a class property
+     * @param  {Object} item sidebar item (as defined in config)
      */
 
   }, {
-    key: 'getClassUrl',
-    value: function getClassUrl(item) {
-      if (item.class) return 'admin-list({ className : \'' + item.class + '\' })';else return '.'; //returns current state
+    key: 'goToUrl',
+    value: function goToUrl(item) {
+      if (item.url) {
+        return this.$window.location.href = item.url;
+      } else if (item.class) {
+        return this.$state.go('admin-list', { className: item.class });
+      } else {
+        return this.$state.go('.'); // returns current state
+      };
     }
   }, {
     key: 'renderHtml',

--- a/dist/admin/views/layout.js
+++ b/dist/admin/views/layout.js
@@ -29,7 +29,7 @@ module.run(['$templateCache', function($templateCache) {
     '\n' +
     '          <!-- These are only displayed when the nav is collapsed -->\n' +
     '          <li ng-repeat="item in ctrl.sidebarItems" class="collapsed-display">\n' +
-    '            <a ui-sref="{{ ctrl.getClassUrl(item) }}" ng-class="{\'active\': ctrl.Admin.className == item.class}">\n' +
+    '            <a ng-click="ctrl.goToUrl(item)" ng-class="{\'active\': ctrl.Admin.className == item.class}">\n' +
     '              <i class="fa fa-{{ item.icon }} fa=fw"></i>&nbsp;&nbsp; {{ item.title }}\n' +
     '            </a>\n' +
     '          </li>\n' +
@@ -56,7 +56,7 @@ module.run(['$templateCache', function($templateCache) {
     '    <ul class="sidebar-nav">\n' +
     '      <li role="separator" class="divider">Navigation</li>\n' +
     '      <li ng-repeat="item in ctrl.sidebarItems">\n' +
-    '        <a ui-sref="{{ ctrl.getClassUrl(item) }}" ng-class="{\'active\': ctrl.Admin.className == item.class}">\n' +
+    '        <a ng-click="ctrl.goToUrl(item)" ng-class="{\'active\': ctrl.Admin.className == item.class}">\n' +
     '          <i class="fa fa-{{ item.icon }} fa=fw"></i>&nbsp;&nbsp; {{ item.title }}\n' +
     '        </a>\n' +
     '      </li>\n' +

--- a/src/admin/admin.controller.js
+++ b/src/admin/admin.controller.js
@@ -238,14 +238,19 @@ class AdminController {
   }
 
   /**
-   * Returns a url for ui-sref fora  sidebar item
-   * @param  {Object} sidebar item (as defined in config)
-   * @return {String} url for class, or current state if not
+   * Goes to the appropriate url after checking if the sidebar item has a URL or a class property
+   * @param  {Object} item sidebar item (as defined in config)
    */
-  getClassUrl(item) {
-    if(item.class) return 'admin-list({ className : \'' + item.class + '\' })';
-    else return '.'; //returns current state
+  goToUrl(item) {
+    if (item.url) {
+      return this.$window.location.href = item.url;
+    } else if (item.class) {
+      return this.$state.go('admin-list', { className: item.class });
+    } else {
+      return this.$state.go('.'); // returns current state
+    };
   }
+
 
   renderHtml(html) {
     return this.$sce.trustAsHtml(html);

--- a/src/admin/views/layout.html
+++ b/src/admin/views/layout.html
@@ -21,7 +21,7 @@
 
           <!-- These are only displayed when the nav is collapsed -->
           <li ng-repeat="item in ctrl.sidebarItems" class="collapsed-display">
-            <a ui-sref="{{ ctrl.getClassUrl(item) }}" ng-class="{'active': ctrl.Admin.className == item.class}">
+            <a ng-click="ctrl.goToUrl(item)" ng-class="{'active': ctrl.Admin.className == item.class}">
               <i class="fa fa-{{ item.icon }} fa=fw"></i>&nbsp;&nbsp; {{ item.title }}
             </a>
           </li>
@@ -48,7 +48,7 @@
     <ul class="sidebar-nav">
       <li role="separator" class="divider">Navigation</li>
       <li ng-repeat="item in ctrl.sidebarItems">
-        <a ui-sref="{{ ctrl.getClassUrl(item) }}" ng-class="{'active': ctrl.Admin.className == item.class}">
+        <a ng-click="ctrl.goToUrl(item)" ng-class="{'active': ctrl.Admin.className == item.class}">
           <i class="fa fa-{{ item.icon }} fa=fw"></i>&nbsp;&nbsp; {{ item.title }}
         </a>
       </li>


### PR DESCRIPTION
Navigates to the normal admin route if the sidebar item has a class name. Navigates to a custom url if sidebar item has a url property instead of class name.
